### PR TITLE
Add math support via mathjax

### DIFF
--- a/_includes/javascript.html
+++ b/_includes/javascript.html
@@ -12,3 +12,18 @@
   ga('create', 'UA-37305346-2', 'auto');
   ga('send', 'pageview');
 </script>
+{% if site.math %}
+<script type="text/x-mathjax-config">
+  MathJax.Hub.Config({
+    extensions: ["tex2jax.js"],
+    jax: ["input/TeX", "output/HTML-CSS"],
+    tex2jax: {
+      inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+      displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+      processEscapes: true
+    },
+    "HTML-CSS": { fonts: ["TeX"] }
+  });
+</script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+{% endif %}

--- a/_includes/javascript.html
+++ b/_includes/javascript.html
@@ -13,17 +13,17 @@
   ga('send', 'pageview');
 </script>
 {% if site.math %}
-<script type="text/x-mathjax-config">
-  MathJax.Hub.Config({
-    extensions: ["tex2jax.js"],
-    jax: ["input/TeX", "output/HTML-CSS"],
-    tex2jax: {
-      inlineMath: [ ['$','$'], ["\\(","\\)"] ],
-      displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
-      processEscapes: true
-    },
-    "HTML-CSS": { fonts: ["TeX"] }
-  });
-</script>
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Config({
+        extensions: ["tex2jax.js"],
+        jax: ["input/TeX", "output/HTML-CSS"],
+        tex2jax: {
+          inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+          displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+          processEscapes: true
+        },
+        "HTML-CSS": { fonts: ["TeX"] }
+      });
+    </script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}


### PR DESCRIPTION
I'd like to add math support for a couple of lessons I'm going to be working on in some fashion or other. This is a simple-ish way to do it.

atm I'm stopping mathjax from being in every page by having a `math: true|false` field in `_config.yml`. If this is a decent solution I'll make a PR for the template to add a field. If the field isn't defined it defaults to old behaviour of not including it. Otherwise it could be a frontmatter for each page, rather than each site, or possibly both (ie, only if site.math && page.math)

Could switch this to doing something similar with katex if that's preferred, I'm just used to mathjax. I believe there's some way to get serverside rendering with katex, but this is probably tricky with github-pages

Example: https://alanocallaghan.github.io/latex-novice-typesetting/01-introduction/index.html
https://github.com/Alanocallaghan/latex-novice-typesetting/blob/gh-pages/_episodes/01-introduction.md